### PR TITLE
Fix typo in Validator._validate_pattern()

### DIFF
--- a/json_schema_validator/validator.py
+++ b/json_schema_validator/validator.py
@@ -276,7 +276,7 @@ class Validator(object):
                 obj=obj,ptn=ptn),
             "Object does not match pattern (expected {ptn})".format(
                 ptn=ptn),
-            sechema_suffic=".pattern"
+            schema_suffix=".pattern"
         )
 
     def _validate_format(self):


### PR DESCRIPTION
Fixes this error:

```
TypeError: _report_error() got an unexpected keyword argument 'sechema_suffic'
```
