### PR TITLE
Make use of simplejson optional

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -6,7 +6,6 @@ Prerequisites
 
 This package has the following prerequisites:
 
-* simplejson 
 * versiontools
 
 To run the test suite you will also need:

--- a/json_schema_validator/shortcuts.py
+++ b/json_schema_validator/shortcuts.py
@@ -20,7 +20,10 @@
 One liners that make the code shorter
 """
 
-import simplejson
+try:
+    import simplejson as json
+except ImportError:
+    import json
 
 from json_schema_validator.schema import Schema
 from json_schema_validator.validator import Validator
@@ -29,7 +32,8 @@ from json_schema_validator.validator import Validator
 def validate(schema_text, data_text):
     """
     Validate specified JSON text (data_text) with specified schema (schema
-    text). Both are converted to JSON objects with :func:`simplesjon.loads`.
+    text). Both are converted to JSON objects with :func:`simplejson.loads`
+    if present or :func:`json.loads`.
 
     :param schema_text:
         Text of the JSON schema to check against
@@ -44,6 +48,7 @@ def validate(schema_text, data_text):
     :raises:
         Whatever may be raised by simplejson (in particular
         :class:`simplejson.decoder.JSONDecoderError`, a subclass of :class:`ValueError`)
+        or json
     :raises:
         Whatever may be raised by
         :meth:`json_schema_validator.validator.Validator.validate`. In particular
@@ -52,6 +57,6 @@ def validate(schema_text, data_text):
 
 
     """
-    schema = Schema(simplejson.loads(schema_text))
-    data = simplejson.loads(data_text)
+    schema = Schema(json.loads(schema_text))
+    data = json.loads(data_text)
     return Validator.validate(schema, data)

--- a/json_schema_validator/tests/test_schema.py
+++ b/json_schema_validator/tests/test_schema.py
@@ -22,7 +22,10 @@ Unit tests for JSON schema
 
 import sys
 
-import simplejson
+if sys.version_info[0] == 2:
+    import simplejson as json
+else:
+    import json
 
 from testscenarios import TestWithScenarios
 from testtools import TestCase
@@ -775,7 +778,7 @@ class SchemaTests(TestWithScenarios, TestCase):
     ]
 
     def test_schema_attribute(self):
-        schema = Schema(simplejson.loads(self.schema))
+        schema = Schema(json.loads(self.schema))
         if hasattr(self, 'expected'):
             for attr, expected_value in self.expected.items():
                 self.assertEqual(

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,17 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with json-schema-validator.  If not, see <http://www.gnu.org/licenses/>.
 
+import sys
+
 from setuptools import setup, find_packages
 
+test_dependencies = [
+    'testscenarios >= 0.1',
+    'testtools >= 0.9.2'
+]
+
+if sys.version_info[0] == 2:
+    test_dependencies.append('simplejson >= 2.0.9')
 
 setup(
     name='json-schema-validator',
@@ -41,11 +50,7 @@ setup(
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
     ],
-    install_requires=[
-        'simplejson >= 2.0.9'],
     setup_requires=[
         'versiontools >= 1.3.1'],
-    tests_require=[
-        'testscenarios >= 0.1',
-        'testtools >= 0.9.2'],
+    tests_require=test_dependencies,
     zip_safe=True)


### PR DESCRIPTION
Use the standard library json if simplejson is not installed.
simplejson doesnt provide any benefits on Python 3.

Use simplejson for tests as it puts strings into str on Python 2.7
whereas json uses unicode, causing many test failures due
to u'..' prefix in error messages.
